### PR TITLE
Split the intialisation of channels from the downloading of configuration

### DIFF
--- a/percival/carrier/channels.py
+++ b/percival/carrier/channels.py
@@ -127,7 +127,12 @@ class Channel(object):
 
         :returns: list of (address, dataword) tuples
         """
-        result = self.command(DeviceCmd.initialize)
+        result = None
+
+        # Send an initialize command to the device if it is supported
+        if self._device_family_features.supports_cmd(DeviceCmd.initialize):
+            result = self.command(DeviceCmd.initialize)
+
         return result
 
 
@@ -158,10 +163,6 @@ class ControlChannel(Channel):
         # Initialise the UARTRegister map
         self._reg_control_settings.initialize_map(settings)
         self._log.debug("Control Settings Map: %s", self._reg_control_settings.fields)
-
-        # Send an initialize command to the device if it is supported
-        if self._device_family_features.supports_cmd(DeviceCmd.initialize):
-            self.cmd_initialize()
 
     def cmd_control_set_value(self, value):
         """

--- a/percival/carrier/devices.py
+++ b/percival/carrier/devices.py
@@ -130,6 +130,9 @@ class AD5242(object):
         self._channel = channel
         self._device = DeviceFamily.AD5242
 
+    def initialize(self):
+        self._channel.cmd_initialize()
+
     def set_value(self, value, timeout=0.1):
         """
         Set the value of the device.
@@ -157,6 +160,9 @@ class AD5263(object):
         self._channel = channel
         self._device = DeviceFamily.AD5263
 
+    def initialize(self):
+        self._channel.cmd_initialize()
+
     def set_value(self, value, timeout=0.1):
         """
         Set the value of the device.
@@ -183,6 +189,9 @@ class AD5669(object):
         self._name = name
         self._channel = channel
         self._device = DeviceFamily.AD5669
+
+    def initialize(self):
+        self._channel.cmd_initialize()
 
     def set_value(self, value, timeout=0.1):
         """

--- a/percival/carrier/test_channels.py
+++ b/percival/carrier/test_channels.py
@@ -31,6 +31,8 @@ class TestChannels(unittest.TestCase):
         self.channel_ini.UART_address = 10
         self.channel_ini.Board_type = const.BoardTypes.bottom
         ctrlChannel = ControlChannel(self.txrx, self.channel_ini, self.settings)
+        # Send a command to initialise the channel
+        ctrlChannel.cmd_initialize()
         # Verify the txrx mock had send_rcv_message called
         self.txrx.send_recv_message.assert_called_with(
             TxMessage(bytes("\x01\x22\x20\x00\x00\x01", encoding="latin-1"), expect_eom=True))

--- a/percival/detector/standalone.py
+++ b/percival/detector/standalone.py
@@ -13,9 +13,9 @@ from percival.detector.ipc_reactor import IpcReactor
 
 
 class PercivalStandalone(object):
-    def __init__(self, initialise_hardware=True):
+    def __init__(self, download_config=True, initialise_hardware=True):
         self._log = logging.getLogger(".".join([__name__, self.__class__.__name__]))
-        self._detector = PercivalDetector(initialise_hardware)
+        self._detector = PercivalDetector(download_config, initialise_hardware)
         self._ctrl_channel = None
         self._status_channel = None
         self._reactor = IpcReactor()

--- a/percival/percivalcontrol.py
+++ b/percival/percivalcontrol.py
@@ -12,7 +12,8 @@ from percival.detector.standalone import PercivalStandalone
 
 def options():
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--init", action="store_true", help="Write the initialisation configuration to the board")
+    parser.add_argument("-l", "--load", action="store_true", help="Download the ini configuration to the board")
+    parser.add_argument("-i", "--init", action="store_true", help="Initialise DAC channels on the board")
     parser.add_argument("-c", "--control", action="store", default="tcp://127.0.0.1:8888", help="ZeroMQ control endpoint")
     parser.add_argument("-s", "--status",  action="store", default="tcp://127.0.0.1:8889", help="ZeroMQ status endpoint")
     args = parser.parse_args()
@@ -24,7 +25,7 @@ def main():
     log.info(args)
 
     # Create the stand alone device
-    percival = PercivalStandalone(args.init)
+    percival = PercivalStandalone(args.load, args.init)
 
     # Initialise the control endpoint
     percival.setup_control_channel(args.control)


### PR DESCRIPTION
Split the intialisation of channels from the downloading of configuration settings from the ini files.  Provided hooks to send the init commands.
Added command line parameter for initialising and loading.  Updated tests to work with the new interface.