### PR TITLE
Ensure that full channel tear down and reconstruction is executed.

### DIFF
--- a/percival/detector/detector.py
+++ b/percival/detector/detector.py
@@ -900,6 +900,7 @@ class PercivalDetector(object):
             # Check if the command is a connection request to the DB
             if command.command_name in str(PercivalCommandNames.cmd_download_channel_cfg):
                 # No parameters required for this command
+                self._percival_params.load_ini()
                 self.load_configuration()
                 self.load_channels()
                 self._active_command.complete(success=True)


### PR DESCRIPTION
Ensure that full channel tear down and reconstruction is executed when the channel command is processed.
This includes reloading the channel configuration ini file.
This resolves issue #57.