### PR TITLE
Added parameter ADC RAMPS / Fskip_duration to chip_readout_settings. …

### DIFF
--- a/percival/carrier/registers.py
+++ b/percival/carrier/registers.py
@@ -669,6 +669,7 @@ class ChipReadoutSettingsMap(RegisterMap):
                          "RESET_PHASE_AB_reset_start":       MapField("RESET_PHASE_AB_reset_start",       21, 16,  0),
                          "RESET_PHASE_AB_reset_stop":        MapField("RESET_PHASE_AB_reset_stop",        21, 16, 16),
                          "DURATION_ADC_ramps_phase":         MapField("DURATION_ADC_ramps_phase",         22, 16,  0),
+						 "ADC_RAMPS_PHASE_Fskip_duration":   MapField("ADC_RAMPS_PHASE_Fskip_duration",   22, 16, 16),
                          "ADC_RAMPS_PHASE_CConvEn_rise":     MapField("ADC_RAMPS_PHASE_CConvEn_rise",     23, 16,  0),
                          "ADC_RAMPS_PHASE_CConvEn_fall":     MapField("ADC_RAMPS_PHASE_CConvEn_fall",     23, 16, 16),
                          "ADC_RAMPS_PHASE_FConvEn_rise":     MapField("ADC_RAMPS_PHASE_FConvEn_rise",     24, 16,  0),


### PR DESCRIPTION
…This is used as anti-hysteresis workaround (RAL way).

@ajgdls A new parameter needs to be added to the present set of chip_readout_settings. Please check if there's something else that needs to be modified.
After this is in place, a Fskip_duration item added under the [ADC_RAMPS_PHASE] section may allow to activate this "anti-hysteresis workaround" which RAL suggested during the latest F2F.