### PR TITLE
rewrite button gui for percival operation

### DIFF
--- a/DESY/W3C3/user_scripts/CrisisPowerdown.sh
+++ b/DESY/W3C3/user_scripts/CrisisPowerdown.sh
@@ -1,0 +1,65 @@
+
+if [[ $1 = '-u0' ]] && [[ $2 -gt 5 ]]; then
+
+#####################################################################################################
+# always the commands in this block need to be executed
+echo "EMERGENCY PERCIVAL POWERDOWN STARTED" 
+
+echo "Exit armed status"
+percival-hl-system-command -c stop_acquisition
+percival-hl-system-command -c forced_stop_acquisition
+percival-hl-system-command -c exit_acquisition_armed_status
+
+echo "Loading settings (ini)..."
+percival-hl-configure-clock-settings -i ./DESY/W3C3/config/01_Clock_Settings/ClockSettings_N00_SAFE_START.ini
+percival-hl-configure-chip-readout-settings -i ./DESY/W3C3/config/02_Chip_Readout_Settings/ChipReadoutSettings_N00_SAFEstart.ini
+percival-hl-configure-system-settings -i ./DESY/W3C3/config/03_System_Settings/SystemSettings_N00_SAFE_START.ini
+echo "Loading settings (xls)..."
+percival-hl-configure-control-groups -i ./DESY/W3C3/config/05_Spreadsheets/DESY_W3C3_Group_Definitions.xls
+percival-hl-configure-monitor-groups -i ./DESY/W3C3/config/05_Spreadsheets/DESY_W3C3_Group_Definitions.xls
+percival-hl-configure-setpoints -i ./DESY/W3C3/config/05_Spreadsheets/DESY_W3C3_Setpoint_Definitions.xls
+
+#####################################################################################################
+
+if [[ $2 -gt 1300 ]]; then
+echo "1300mA actions:"
+echo " Ramp down Current Biases..."
+percival-hl-scan-setpoints -i 08_0_CurrentBiases_ON -f 07_0_VoltageReferences_ON -n 4 -d 2000
+fi
+
+if [[ $2 -gt 850 ]]; then
+echo "850mA actions:"
+echo " Ramp down Voltage references..."
+percival-hl-scan-setpoints -i 07_0_VoltageReferences_ON -f 06_0_PixelVoltages_ON -n 4 -d 2000
+echo " Ramp down PixelVoltages..."
+percival-hl-scan-setpoints -i 06_0_PixelVoltages_ON -f 05_0_PixelVoltages_ON -n 4 -d 2000
+percival-hl-scan-setpoints -i 05_0_PixelVoltages_ON -f 04_0_PixelVoltages_ON -n 4 -d 2000
+percival-hl-scan-setpoints -i 04_0_PixelVoltages_ON -f 03_0_PixelVoltages_ON -n 4 -d 2000
+percival-hl-scan-setpoints -i 03_0_PixelVoltages_ON -f 02_0_LVDS_ON -n 4 -d 2000
+echo " disabling IOs"
+percival-hl-system-command -c disable_LVDS_IOs
+fi
+
+
+if [[ $2 -gt 550 ]]; then
+echo "550mA actions:"
+echo " Ramp down Voltage Supplies and LVDS IOs..."
+percival-hl-scan-setpoints -i 02_0_LVDS_ON -f 01_0_VDD_ON -n 4 -d 2000
+fi
+
+
+if [[ $2 -gt 100 ]]; then
+echo "100mA actions:"
+echo " setpoint 01 to 00"
+percival-hl-scan-setpoints -i 01_0_VDD_ON -f 00_0_0V0A -n 4 -d 2000
+fi
+
+
+echo "EMERGENCY PERCIVAL POWERDOWN COMPLETED"
+echo "now please power off Wiener"
+
+else
+    echo "help: this script powers down percival based on a u0 current in mA. Specify eg -u0 1000"
+    echo " run it in the percivalui directory of the pc running odin_server"
+fi
+

--- a/static/index.html
+++ b/static/index.html
@@ -577,6 +577,10 @@
 									<tr><td>File</td><td align="center" id="fp1-hdf-file-path"></td><td align="center" id="fp2-hdf-file-path"></td></tr>
 									<tr><td>Writing</td><td align="center" id="fp1-writing"></td><td align="center" id="fp2-writing"></td></tr>
 									<tr><td>Frames Written</td><td align="center" id="fp1-hdf-written"></td><td align="center" id="fp2-hdf-written"></td></tr>
+
+									<tr><td>Calibration loaded</td><td align="center" id="fp1-calib-constantsfile"></td><td align="center" id="fp2-calib-constantsfile"></td></tr>
+									<tr><td>CMA</td><td align="center" id="fp1-calib-cmaavg"></td><td align="center" id="fp2-calib-cmaavg"></td></tr>
+									<tr><td>Dark-frame</td><td align="center" id="fp1-calib-darkframe"></td><td align="center" id="fp2-calib-darkframe"></td></tr>
 									<!--<tr><td>Debug Level:</td><td align="center"><div class="dropdown"><select id="fp1-debug">
 												<option value="0">None</option>
 												<option value="1">Commands</option>

--- a/static/js/odin-data.js
+++ b/static/js/odin-data.js
@@ -77,11 +77,23 @@ function read_fp_status()
 function populate_fp_table(fp_index, fp)
 {
     $('#' + fp_index + '-shared-mem').html(led_html(fp['shared_memory']['configured'], 'green', 20));
+    // assume that it has an hdf adapter loaded, else throw and terminate.
     $('#' + fp_index + '-hdf-processes').html(fp['hdf']['processes']);
     $('#' + fp_index + '-hdf-rank').html(fp['hdf']['rank']);
     $('#' + fp_index + '-hdf-written').html(fp['hdf']['frames_written'] + " / " + fp['hdf']['frames_max']);
     $('#' + fp_index + '-hdf-file-path').html(fp['hdf']['file_name']);
     $('#' + fp_index + '-writing').html(led_html(fp['hdf']['writing'], 'green', 20));
+
+    if ("calib" in fp)
+    {
+      $('#' + fp_index + '-calib-constantsfile').html(led_html(fp['calib']['constantsfile'], 'green', 20));
+      $('#' + fp_index + '-calib-cmaavg').html(led_html(0<=fp['calib']['cmaavg'], 'green', 20));
+      $('#' + fp_index + '-calib-darkframe').html(led_html(fp['calib']['darkframe'], 'green', 20));
+    }
+    else
+    {
+      // if someone unloads the calib plugin during run, the leds will stay on. But this is unlikely.
+    }
 }
 
 function empty_fp_table(fp_index)
@@ -92,6 +104,10 @@ function empty_fp_table(fp_index)
     $('#' + fp_index + '-hdf-written').html('');
     $('#' + fp_index + '-hdf-file-path').html('');
     $('#' + fp_index + '-writing').html('');
+
+    $('#' + fp_index + '-calib-constantsfile').html('');
+    $('#' + fp_index + '-calib-cmaavg').html('');
+    $('#' + fp_index + '-calib-darkframe').html('');
 }
 
 function send_fp_command(command, data)

--- a/static/js/percival.js
+++ b/static/js/percival.js
@@ -1060,7 +1060,7 @@ function flash_element(element)
 function led_html(value, colour, width)
 {
   var html_text = "<img width=" + width + "px src=img/";
-  if (value == 0){
+  if (Boolean(value)==false){
     html_text += "led-off";
   } else {
     html_text +=  colour + "-led-on";

--- a/user_scripts/buttons.py
+++ b/user_scripts/buttons.py
@@ -3,7 +3,7 @@
 import json;
 import socket;
 import sys;
-from Tkinter import *
+from Tkinter import *;
 import socketfns;
 
 if len(sys.argv)==2 and sys.argv[1]=="--shutdown-server":
@@ -12,56 +12,66 @@ if len(sys.argv)==2 and sys.argv[1]=="--shutdown-server":
     exit(0);
 
 master = Tk();
-master.geometry("400x300+200+200");
+master.geometry("600x300+200+200");
 master.title("Percival Operation");
 
-def btnCallback(buttxt):
-    actions = socketfns.getActions();
+desc2but = {};
+count = 0;
+
+def btnCallback(tk):
+    global desc2but;
+    # be careful with tk here: it may not be concurrent.
     # this button callback should also disable the button so it doesn't
     # get pressed twice; we may as well disable all the buttons then.
-    for i in range(0,len(actions)):
-        but = f.grid_slaves(column=1,row=i)[0];
+    for but in desc2but.values():
         but.configure(state=DISABLED);
 
-    if buttxt in actions:
-        print "toggling action ", actions.index(buttxt);
-        socketfns.togTask(buttxt);
+    if(tk.get("type")=="level"):
+        socketfns.togTask(tk.get("description"));
+    elif(tk.get("type")=="action"):
+        socketfns.doTask(tk.get("description"));
+        but = desc2but.get(tk.get("description"));
+        but.configure(bg="orange");
 
-
-def updateCanvas(status):
-    for i in range(0,len(actions)):
+def updateCanvas(levels):
+    for i in range(0,len(levels)):
         cv = f.grid_slaves(column=2, row=i)[0];
-        state = status[actions[i]];
+        state = levels[i].get("state");
         if state=="done":
             cv.configure(bg="green");
         elif state=="not done":
             cv.configure(bg="red");
-        else:
+        elif state and "doing" in state:
             cv.configure(bg="orange");
+        else:
+            cv.configure(bg="black");
 
-def updateButtons(status):
-    for i in range(0,len(actions)):
-        but = f.grid_slaves(column=1,row=i)[0];
-        canChange = True;
-        if 0<i:
-            canChange &= (status[actions[i-1]]=="done");
-        if i+1<len(actions):
-            canChange &= (status[actions[i+1]]=="not done");
+def updateButtons(levels):
+    for lv in levels:
+        but = desc2but[lv.get("description")];
 
-        taskStatus = status[actions[i]];
-            
-        if canChange and (taskStatus=="done" or taskStatus=="not done"):
+        if lv.get("enable"):
             but.configure(state=NORMAL);
         else:
             but.configure(state=DISABLED);
 
+        for ac in lv.get("actions") or []:
+            but = desc2but[ac.get("description")];
+            if(ac.get("enable")):
+                but.configure(state=NORMAL, bg="#d9d9d9");
+            else:
+                but.configure(state=DISABLED);
+        
+
 def updateStatus():
+    global count;
     # updateStatus and button callbacks won't be called simultaneously;
     # master seems to be single-threaded, but it will queue functions to call
-    print "update status";
-    status = socketfns.getStatus();
-    updateCanvas(status);
-    updateButtons(status);
+    print "update status", count;
+    count += 1;
+    levels = socketfns.getStatus();
+    updateCanvas(levels);
+    updateButtons(levels);
     master.after(1000, updateStatus);
 
 # borderwidth is internal border
@@ -69,11 +79,11 @@ f = Frame(master, height=320, width=400, borderwidth=10, highlightbackground="re
 f.pack_propagate(0); # don't shrink
 f.pack();
 
-actions = socketfns.getActions();
-row = 0;
+levels = socketfns.getStatus();
 
-for ac in actions:
-    t0 = Label(f, height=1, width=30, text=ac);
+for lv in levels:
+    row = lv.get("level");
+    t0 = Label(f, height=1, width=30, text=lv.get("description"));
     t0.grid(row=row, column=0);
 #  t0.insert(END, "task1");
 
@@ -83,9 +93,15 @@ for ac in actions:
            bg="grey");
     c0.grid(row=row, column=2);
 
-    b0 = Button(f, text="on/off", state=DISABLED, command=lambda bac=ac: btnCallback(bac));
+    b0 = Button(f, text="on/off", state=DISABLED, command=lambda bac=lv: btnCallback(bac));
     b0.grid(row=row, column=1);
-    row = row + 1;
+    desc2but[lv.get("description")]=b0;
+
+    for ac in lv.get("actions") or []:
+        b1 = Button(f, text=ac.get("description"), state=DISABLED, command=lambda bac=ac: btnCallback(bac));
+        desc2but[ac.get("description")]=b1;
+        aidx = ac.get("aidx");
+        b1.grid(row=row, column=3+aidx, padx=5, sticky=E);
 
 master.after(1000, updateStatus);
 mainloop();

--- a/user_scripts/buttons.py
+++ b/user_scripts/buttons.py
@@ -6,9 +6,10 @@ import sys;
 from Tkinter import *;
 import socketfns;
 
+# we should have exit-server instead
 if len(sys.argv)==2 and sys.argv[1]=="--shutdown-server":
     print "sending shutdown message to server";
-    socketfns.sendMsg("shutdown", None);
+    socketfns.sendMsg("exit", None);
     exit(0);
 
 master = Tk();
@@ -70,6 +71,9 @@ def updateStatus():
     print "update status", count;
     count += 1;
     levels = socketfns.getStatus();
+    if len(levels)==1 and levels[0].has_key("shutdownPerc"):
+        print "AUTOSHUTDOWN RUNNING";
+        exit(0);
     updateCanvas(levels);
     updateButtons(levels);
     master.after(1000, updateStatus);

--- a/user_scripts/queryUPS.py
+++ b/user_scripts/queryUPS.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+
+import threading;
+import socket;
+import time;
+import json;
+import os;
+import os.path;
+import requests;
+import subprocess;
+import serial;
+
+def checkUPS():
+
+    try:
+    # this will raise if it cant open the device
+        ser = serial.Serial("/dev/ttyUSB0", baudrate=2400, parity=serial.PARITY_NONE, stopbits=serial.STOPBITS_ONE, bytesize=serial.EIGHTBITS, timeout=1);
+        ser.write(b"Q1\r");
+        reply = ser.read(47);
+       # print reply;
+        # we need a space before the zeros to make sure we match the first bit
+        if(0 < reply.index(b" 0000000")):
+            return True;            
+
+    except Exception as e:
+       # print e;
+        pass;
+        
+    return False; 
+
+
+if __name__ == "__main__":
+    if checkUPS():
+        print "UPS is ok";
+    else:
+        print "UPS IS UNPOWERED OR DISCONNECTED";  
+    
+
+
+
+
+
+
+
+
+
+

--- a/user_scripts/socketfns.py
+++ b/user_scripts/socketfns.py
@@ -20,26 +20,21 @@ def sendMsg(command, task):
 
     ji = {};
 
-    ji["task:"] = task;
-    ji["cmd:"] = command;
+    ji["cmd"] = command;
+    ji["task"] = task;
+
 
     jis = json.dumps(ji);
     s.send(jis);
     ji = {};
-    back = s.recv(512);
+    back = s.recv(2048);
     s.close();
 
     if back:
+     #   print "returned", back;
         ji = json.loads(back);
 
     return ji;
-
-def getActions():
-    dd = sendMsg("gettasks", None);
-    if dd.has_key("tasklist:"):
-        return dd["tasklist:"];
-    else:
-        return [];
 
 def doTask(task):
     dd = sendMsg("start", task);
@@ -51,9 +46,7 @@ def togTask(task):
     dd = sendMsg("toggle", task);
 
 def getStatus():
-    dd = sendMsg("querystatus", None);
-    if dd.has_key("status:"):
-        return dd["status:"];
-    else:
-        return {};
+    levels = sendMsg("getLevels", None);
+    return levels;
+
 

--- a/user_scripts/socketfns.py
+++ b/user_scripts/socketfns.py
@@ -4,7 +4,9 @@ import socket;
 import sys;
 import json;
 
-HOST = '172.23.190.166'  # ws390 at Diamond. This is the pc you run server.py on.
+# I am inclined to move all this into buttons.py and/or use zmq.
+
+HOST = '172.23.17.54'  # ws450 at Diamond. This is the pc you run server.py on.
 PORT = 8889;      # Port to listen on (non-privileged ports are > 1023)
 
 """

--- a/user_scripts/wiener/mainswitchON.sh
+++ b/user_scripts/wiener/mainswitchON.sh
@@ -3,6 +3,9 @@
 # Switch the WIENER On
 
 WIENER_IP=172.23.16.179
+# note that you need to have WIENER-CRATE-MIB.txt installed in /usr/share/snmp/mibs
+# and that the first time you plug it in, you cant use this script to turn it on,
+# you must use the physical switch.
 
 echo Switching the WIENER Power Supply ON
 


### PR DESCRIPTION
this is a major overhaul of the percival gui. The config is now easy to read as a dict in server.py, and you can have actions after reaching level n. The enable / disable of the buttons is now set in the server instead of the buttons. I can't see this transporting to http or epics because it has become too complex.