### PR TITLE
minimize the action of scan_set_points

### DIFF
--- a/percival/detector/set_point.py
+++ b/percival/detector/set_point.py
@@ -244,10 +244,10 @@ class SetPointControl(object):
             if self._scanning:
                 for sp in self._scan_points:
                     try:
-                        # For a scan index of greater than 0 check to see if we are being asked to scan to the
-                        # same point.  If we are then do not actually send the demand
-                        if self._scan_index == 0 or int(self._scan_points[sp][self._scan_index]) != \
-                                    int(self._scan_points[sp][self._scan_index - 1]):
+                        # If the stages are all the same, we set nothing.
+                        # This means that some values are preserved over the scan, and may not
+                        # finish at the value of setpoint. You must use scan_apply_setpoint for that.
+                        if int(self._scan_points[sp][0]) != int(self._scan_points[sp][-1]):
                             self._detector.set_value(sp, int(self._scan_points[sp][self._scan_index]))
                     except Exception as ex:
                         # Caught an exception whilst scanning, so exit out and set error


### PR DESCRIPTION
this is a significant change, altering what scan_setpoints does. I am assuming that the detector state is setpoint0 when we start the scan, and so we can remove a lot of the set_value calls.